### PR TITLE
Fix connector deprecated each()

### DIFF
--- a/connectors/components/ajaxmanager/lang.js.php
+++ b/connectors/components/ajaxmanager/lang.js.php
@@ -21,7 +21,7 @@ $entries = $modx->lexicon->fetch();
 echo '
 Ext.applyIf(MODx.lang,{';
 $s = '';
-while (list($k,$v) = each ($entries)) {
+foreach ($entries as $k => $v) {
     $s .= "'$k': ".'"'.esc($v).'",';
 }
 $s = trim($s,',');


### PR DESCRIPTION
Due to multiple warning in log "(WARN @www\connectors\ajaxmanager\lang.js.php : 24) PHP deprecated: The each() function is deprecated." and the fact that "Function each() has been deprecated as of PHP 7.2.0. Relying on this function is highly discouraged." I think better to fix it :)